### PR TITLE
Fix description error in doc: majorVersion in MQTT topic should be v2 for version 2.0 of the VDA5050 specification

### DIFF
--- a/doc/v2.0/runtime-behaviour.adoc
+++ b/doc/v2.0/runtime-behaviour.adoc
@@ -28,11 +28,11 @@ So, with the vehicle property values being set as
 
 the driver would publish or subscribe to the following topics:
 
-* `uagv/v1/Some_Company/AGV-XY-1234/order` (published to)
-* `uagv/v1/Some_Company/AGV-XY-1234/instantActions` (published to)
-* `uagv/v1/Some_Company/AGV-XY-1234/state` (subscribed to)
-* `uagv/v1/Some_Company/AGV-XY-1234/visualization` (subscribed to)
-* `uagv/v1/Some_Company/AGV-XY-1234/connection` (subscribed to)
+* `uagv/v2/Some_Company/AGV-XY-1234/order` (published to)
+* `uagv/v2/Some_Company/AGV-XY-1234/instantActions` (published to)
+* `uagv/v2/Some_Company/AGV-XY-1234/state` (subscribed to)
+* `uagv/v2/Some_Company/AGV-XY-1234/visualization` (subscribed to)
+* `uagv/v2/Some_Company/AGV-XY-1234/connection` (subscribed to)
 
 NOTE: It is not recommended to use non-ASCII characters (e.g. German umlauts), spaces etc. in MQTT topic names, as they may make it more difficult to investigate in case of problems.
 Since the topic names used are derived from the property values listed above, it is also not recommended to use such characters in these property values.


### PR DESCRIPTION
## Description

In the doc files,
- a minor error: majorVersion in an MQTT topic, interfaceName/majorVersion/manufacturer/serialNumber/topic, should be v2 for version 2.0 of the VDA5050 specification.
~~- a grammatical mistake: an MQTT topic is published or subscribed to, not "published to".~~


## Checklist

- [x] You have the right to contribute the code/documentation/assets to this project, and you agree to contribute it under the terms of the project's license(s).
- [x] All changes have been made on a separate branch (not master) in a fork.
- [x] The whole project compiles correctly and all tests pass, i.e. `gradlew clean build` succeeds with the changes made, and without unavoidable compiler/toolchain warnings.
- [ ] New tests covering the change have been added, if it is possible / makes sense.
- [x] The documentation has been extended, if necessary.
- [x] The PR contains a proposal for a _well-formed_ commit message that mentions all authors who contributed to the PR.
      (The commits in the PR will be squashed into one commit on the base branch, and your proposed message is intended to be used for this commit. See below for a template you can use for the message. See [this blog post](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) and [this one](https://chris.beams.io/posts/git-commit/#seven-rules) for more on well-formed commit messages.)

## Proposed squash commit message

<!--
A proposed message for the eventual squashed commit.
Please stick to the following pattern:

- A short one-line summary (max. 50 characters).
- A blank line.
- A detailed explanation of the changes introduced by this merge request.
  Each line should not exceed 72 characters.
*********1*********2*********3*********4*********5*********6*********7** (<-- Ruler for line width assistance)
-->
```
Correct majorVersion in MQTT topics in doc

In the doc files,
* majorVersion in an MQTT topic, interfaceName/majorVersion/
  manufacturer/serialNumber/topic, should be v2 for version 2.0 
  of the VDA5050 specification.
```
~~* An MQTT topic is published or subscribed to, not "published to".~~
<!--
*********1*********2*********3*********4*********5*********6*********7** (<-- Ruler for line width assistance)
-->