### PR TITLE
Fix bug of no error/information data for v2.0

### DIFF
--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/StateMappings.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/StateMappings.java
@@ -114,6 +114,10 @@ public class StateMappings {
     requireNonNull(state, "state");
     requireNonNull(errorLevel, "errorLevel");
 
+    if (state.getErrors() == null || state.getErrors().isEmpty()) {
+      return "";
+    }
+
     return String.join(
         ", ",
         state.getErrors().stream()
@@ -137,6 +141,10 @@ public class StateMappings {
   public static String toInfoPropertyValue(@Nonnull State state, @Nonnull InfoLevel infoLevel) {
     requireNonNull(state, "state");
     requireNonNull(infoLevel, "infoLevel");
+
+    if (state.getErrors() == null || state.getErrors().isEmpty()) {
+      return "";
+    }
 
     return String.join(
         ", ",


### PR DESCRIPTION
## Description

Exception happens in function toErrorPropertyValue / toInfoPropertyValue in Statemappings.java if no "errors" or "Information" data, but "errors" and "Information" are optional for v2.0.

## Checklist

- [X] You have the right to contribute the code/documentation/assets to this project, and you agree to contribute it under the terms of the project's license(s).
- [X] All changes have been made on a separate branch (not master) in a fork.
- [X] The whole project compiles correctly and all tests pass, i.e. `gradlew clean build` succeeds with the changes made, and without unavoidable compiler/toolchain warnings.
- [ ] New tests covering the change have been added, if it is possible / makes sense.
- [ ] The documentation has been extended, if necessary.
- [X] The PR contains a proposal for a _well-formed_ commit message that mentions all authors who contributed to the PR.
      (The commits in the PR will be squashed into one commit on the base branch, and your proposed message is intended to be used for this commit. See below for a template you can use for the message. See [this blog post](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) and [this one](https://chris.beams.io/posts/git-commit/#seven-rules) for more on well-formed commit messages.)

## Proposed squash commit message

<!--
A proposed message for the eventual squashed commit.
Please stick to the following pattern:

- A short one-line summary (max. 50 characters).
- A blank line.
- A detailed explanation of the changes introduced by this merge request.
  Each line should not exceed 72 characters.
*********1*********2*********3*********4*********5*********6*********7** (<-- Ruler for line width assistance)
-->
```
A short one-line summary (max. 50 characters)

A more detailed explanation of the changes introduced by this merge
request.

* You can use lists here, too.
* Each line should not exceed 72 characters.

Co-authored-by: NAME <EMAIL>
```
<!--
*********1*********2*********3*********4*********5*********6*********7** (<-- Ruler for line width assistance)
-->
