### PR TITLE
Send initPosition coordinates as numeric values

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,9 @@ toc::[]
 
 == Unreleased
 
+* New features and enhancements:
+** For VDA5050 2.0, in Kernel Control Center, the `initPosition` instant action now sends the `x`, `y`, and `theta` parameters as JSON numbers (floats) instead of strings.
+   These parameters are parsed as `Double` during message mapping, and the UI validates that they are provided as valid numeric values before sending.
 * Changes affecting developers:
 ** Update Gradle wrapper to 9.5.1.
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,8 +21,9 @@ toc::[]
 == Unreleased
 
 * New features and enhancements:
-** For VDA5050 2.0, in Kernel Control Center, the `initPosition` instant action now sends the `x`, `y`, and `theta` parameters as JSON numbers (floats) instead of strings.
-   These parameters are parsed as `Double` during message mapping, and the UI validates that they are provided as valid numeric values before sending.
+** For VDA5050 1.1 and 2.0, in Kernel Control Center, the `initPosition` action's `x`, `y`, and `theta` parameters are now sent as JSON numbers (floats) instead of strings, both in instant action and order messages.
+   These parameters are parsed as `Double` during message mapping, and the UI validates that they are provided as valid finite numbers before sending.
+   If such a parameter cannot be parsed as a finite number, the enclosing instant action or order message is not sent at all.
 * Changes affecting developers:
 ** Update Gradle wrapper to 9.5.1.
 

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/CommAdapterMessageMapper.java
@@ -225,28 +225,6 @@ public class CommAdapterMessageMapper {
     return Optional.of(action);
   }
 
-  private Optional<Object> parseParameterValue(String actionType, String paramKey, String value) {
-    // Only parse numeric parameters for well-known action types/keys. Prevent accidental
-    // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
-    if (Objects.equals(actionType, InitPosition.ACTION_TYPE)
-        && (Objects.equals(paramKey, InitPosition.PARAMKEY_X)
-            || Objects.equals(paramKey, InitPosition.PARAMKEY_Y)
-            || Objects.equals(paramKey, InitPosition.PARAMKEY_THETA))) {
-      try {
-        double parsed = Double.parseDouble(value);
-        if (!Double.isFinite(parsed)) {
-          return Optional.empty();
-        }
-        return Optional.of(parsed);
-      }
-      catch (NumberFormatException e) {
-        return Optional.empty();
-      }
-    }
-
-    return Optional.of(value);
-  }
-
   private Node createNode(String pointName, long sequenceId) {
     return new Node(
         pointName,
@@ -271,5 +249,27 @@ public class CommAdapterMessageMapper {
         endNodeId,
         List.of()
     );
+  }
+
+  private Optional<Object> parseParameterValue(String actionType, String paramKey, String value) {
+    // Only parse numeric parameters for well-known action types/keys. Prevent accidental
+    // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
+    if (Objects.equals(actionType, InitPosition.ACTION_TYPE)
+        && (Objects.equals(paramKey, InitPosition.PARAMKEY_X)
+            || Objects.equals(paramKey, InitPosition.PARAMKEY_Y)
+            || Objects.equals(paramKey, InitPosition.PARAMKEY_THETA))) {
+      try {
+        double parsed = Double.parseDouble(value);
+        if (!Double.isFinite(parsed)) {
+          return Optional.empty();
+        }
+        return Optional.of(parsed);
+      }
+      catch (NumberFormatException e) {
+        return Optional.empty();
+      }
+    }
+
+    return Optional.of(value);
   }
 }

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/CommAdapterMessageMapper.java
@@ -228,10 +228,10 @@ public class CommAdapterMessageMapper {
   private Optional<Object> parseParameterValue(String actionType, String paramKey, String value) {
     // Only parse numeric parameters for well-known action types/keys. Prevent accidental
     // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
-    if (InitPosition.ACTION_TYPE.equals(actionType)
-        && (InitPosition.PARAMKEY_X.equals(paramKey)
-            || InitPosition.PARAMKEY_Y.equals(paramKey)
-            || InitPosition.PARAMKEY_THETA.equals(paramKey))) {
+    if (Objects.equals(actionType, InitPosition.ACTION_TYPE)
+        && (Objects.equals(paramKey, InitPosition.PARAMKEY_X)
+            || Objects.equals(paramKey, InitPosition.PARAMKEY_Y)
+            || Objects.equals(paramKey, InitPosition.PARAMKEY_THETA))) {
       try {
         double parsed = Double.parseDouble(value);
         if (!Double.isFinite(parsed)) {

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/CommAdapterMessageMapper.java
@@ -17,12 +17,14 @@ import static org.opentcs.commadapter.vehicle.vda5050.v1_1.CommAdapterMessages.S
 
 import com.google.inject.assistedinject.Assisted;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.opentcs.commadapter.vehicle.vda5050.v1_1.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.Action;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.ActionParameter;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.BlockingType;
@@ -109,16 +111,22 @@ public class CommAdapterMessageMapper {
         destinationNodeName.get(),
         1
     );
-    toAction(
+    boolean actionRequested = mapValueExtractor.extractString(
+        SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
+        message.getParameters()
+    ).isPresent();
+    Optional<Action> action = toAction(
         message.getParameters(),
         SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
         SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_ID,
         SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_DESCRIPTION,
         SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_BLOCKING_TYPE,
         SEND_ORDER_PARAM_PARAMETER_PATTERN
-    ).ifPresent(action -> {
-      destinationNode.setActions(List.of(action));
-    });
+    );
+    if (actionRequested && action.isEmpty()) {
+      return Optional.empty();
+    }
+    action.ifPresent(a -> destinationNode.setActions(List.of(a)));
 
     Edge edge = createEdge(
         edgeName.get(),
@@ -195,26 +203,48 @@ public class CommAdapterMessageMapper {
     );
 
     actionDescription.ifPresent(action::setActionDescription);
-    record ParameterMatcher(Map.Entry<String, String> parameter, Matcher matcher) {}
-    action.setActionParameters(
-        messageParameters.entrySet().stream()
-            .map(
-                entry -> new ParameterMatcher(
-                    entry,
-                    actionParameterPattern.matcher(entry.getKey())
-                )
-            )
-            .filter(parameterMatcher -> parameterMatcher.matcher.matches())
-            .map(
-                parameterMatcher -> new ActionParameter(
-                    parameterMatcher.matcher.group(1),
-                    parameterMatcher.parameter.getValue()
-                )
-            )
-            .toList()
-    );
+
+    List<ActionParameter> actionParameters = new ArrayList<>();
+    for (Map.Entry<String, String> entry : messageParameters.entrySet()) {
+      Matcher matcher = actionParameterPattern.matcher(entry.getKey());
+      if (!matcher.matches()) {
+        continue;
+      }
+
+      String paramKey = matcher.group(1);
+      Optional<Object> parsedValue = parseParameterValue(
+          action.getActionType(), paramKey, entry.getValue()
+      );
+      if (parsedValue.isEmpty()) {
+        return Optional.empty();
+      }
+      actionParameters.add(new ActionParameter(paramKey, parsedValue.get()));
+    }
+    action.setActionParameters(actionParameters);
 
     return Optional.of(action);
+  }
+
+  private Optional<Object> parseParameterValue(String actionType, String paramKey, String value) {
+    // Only parse numeric parameters for well-known action types/keys. Prevent accidental
+    // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
+    if (InitPosition.ACTION_TYPE.equals(actionType)
+        && (InitPosition.PARAMKEY_X.equals(paramKey)
+            || InitPosition.PARAMKEY_Y.equals(paramKey)
+            || InitPosition.PARAMKEY_THETA.equals(paramKey))) {
+      try {
+        double parsed = Double.parseDouble(value);
+        if (!Double.isFinite(parsed)) {
+          return Optional.empty();
+        }
+        return Optional.of(parsed);
+      }
+      catch (NumberFormatException e) {
+        return Optional.empty();
+      }
+    }
+
+    return Optional.of(value);
   }
 
   private Node createNode(String pointName, long sequenceId) {

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
@@ -15,6 +15,7 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.CommAdapterMessages;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.ProcessModelImpl;
+import org.opentcs.commadapter.vehicle.vda5050.v1_1.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.controlcenter.action.ActionConfigurationPanel;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.Action;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.instantactions.InstantActions;
@@ -689,7 +690,14 @@ public class ControlPanel
         path.getName()
     );
 
-    newOrderActionConfigurationPanel.getAction().ifPresent(action -> {
+    Optional<Action> maybeAction = newOrderActionConfigurationPanel.getAction();
+    if (maybeAction.isPresent()) {
+      Action action = maybeAction.get();
+
+      if (!validateInitPositionNumericParams(action)) {
+        return;
+      }
+
       messageParameters.put(
           CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
           action.getActionType()
@@ -715,7 +723,7 @@ public class ControlPanel
               actionParameter.getValue().toString()
           )
       );
-    });
+    }
 
     sendAdapterMessage(
         new VehicleCommAdapterMessage(CommAdapterMessages.SEND_ORDER_TYPE, messageParameters)
@@ -727,7 +735,13 @@ public class ControlPanel
   }//GEN-LAST:event_enableAdapterCheckBoxActionPerformed
 
   private void sendInstantActionButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_sendInstantActionButtonActionPerformed
-    instantActionConfigurationPanel.getAction().ifPresent(action -> {
+    Optional<Action> maybeInstant = instantActionConfigurationPanel.getAction();
+    if (maybeInstant.isPresent()) {
+      Action action = maybeInstant.get();
+      if (!validateInitPositionNumericParams(action)) {
+        return;
+      }
+
       Map<String, String> messageParameters = new HashMap<>();
 
       messageParameters.put(
@@ -761,7 +775,7 @@ public class ControlPanel
               CommAdapterMessages.SEND_INSTANT_ACTION_TYPE, messageParameters
           )
       );
-    });
+    }
   }//GEN-LAST:event_sendInstantActionButtonActionPerformed
 
   private void applyLastOrderButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_applyLastOrderButtonActionPerformed
@@ -827,6 +841,49 @@ public class ControlPanel
       return Optional.empty();
     }
     return Optional.of(lastNode.getActions().get(0));
+  }
+
+  /**
+   * Validates that x, y, and theta parameters of an initPosition action are valid finite numbers.
+   * Shows an error dialog and returns false if any are invalid.
+   *
+   * @return true if validation passes (or action is not initPosition), false otherwise.
+   */
+  private boolean validateInitPositionNumericParams(Action action) {
+    if (!InitPosition.ACTION_TYPE.equals(action.getActionType())) {
+      return true;
+    }
+
+    for (var ap : action.getActionParameters()) {
+      if (!InitPosition.PARAMKEY_X.equals(ap.getKey())
+          && !InitPosition.PARAMKEY_Y.equals(ap.getKey())
+          && !InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
+        continue;
+      }
+
+      Object v = ap.getValue();
+      if (v instanceof Number) {
+        continue;
+      }
+
+      try {
+        double parsed = Double.parseDouble(String.valueOf(v));
+        if (!Double.isFinite(parsed)) {
+          throw new NumberFormatException("Non-finite value: " + v);
+        }
+      }
+      catch (NumberFormatException ex) {
+        JOptionPane.showMessageDialog(
+            this,
+            "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
+            "Invalid parameter",
+            JOptionPane.ERROR_MESSAGE
+        );
+        return false;
+      }
+    }
+
+    return true;
   }
 
   // FORMATTER:OFF

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
@@ -18,6 +18,7 @@ import org.opentcs.commadapter.vehicle.vda5050.v1_1.ProcessModelImpl;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.controlcenter.action.ActionConfigurationPanel;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.Action;
+import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.ActionParameter;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.instantactions.InstantActions;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.order.Node;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.order.Order;
@@ -690,44 +691,52 @@ public class ControlPanel
         path.getName()
     );
 
-    Optional<Action> maybeAction = newOrderActionConfigurationPanel.getAction();
-    if (maybeAction.isPresent()) {
-      Action action = maybeAction.get();
+    try {
+      Optional<Action> maybeAction = newOrderActionConfigurationPanel.getAction();
+      if (maybeAction.isPresent()) {
+        Action action = maybeAction.get();
 
-      if (!validateInitPositionNumericParams(action)) {
-        return;
+        validateParameters(action);
+
+        messageParameters.put(
+            CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
+            action.getActionType()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_ID,
+            action.getActionId()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_BLOCKING_TYPE,
+            action.getBlockingType().name()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_DESCRIPTION,
+            action.getActionDescription()
+        );
+
+
+        action.getActionParameters().forEach(
+            actionParameter -> messageParameters.put(
+                CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_PARAMETER_PREFIX
+                    + actionParameter.getKey(),
+                actionParameter.getValue().toString()
+            )
+        );
       }
 
-      messageParameters.put(
-          CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
-          action.getActionType()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_ID,
-          action.getActionId()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_BLOCKING_TYPE,
-          action.getBlockingType().name()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_DESCRIPTION,
-          action.getActionDescription()
-      );
-
-
-      action.getActionParameters().forEach(
-          actionParameter -> messageParameters.put(
-              CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_PARAMETER_PREFIX
-                  + actionParameter.getKey(),
-              actionParameter.getValue().toString()
-          )
+      sendAdapterMessage(
+          new VehicleCommAdapterMessage(CommAdapterMessages.SEND_ORDER_TYPE, messageParameters)
       );
     }
-
-    sendAdapterMessage(
-        new VehicleCommAdapterMessage(CommAdapterMessages.SEND_ORDER_TYPE, messageParameters)
-    );
+    catch (InvalidActionParameterException ex) {
+      JOptionPane.showMessageDialog(
+          this,
+          ex.getMessage(),
+          "Invalid parameter",
+          JOptionPane.ERROR_MESSAGE
+      );
+    }
   }//GEN-LAST:event_sendOrderButtonActionPerformed
 
   private void enableAdapterCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_enableAdapterCheckBoxActionPerformed
@@ -735,45 +744,54 @@ public class ControlPanel
   }//GEN-LAST:event_enableAdapterCheckBoxActionPerformed
 
   private void sendInstantActionButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_sendInstantActionButtonActionPerformed
-    Optional<Action> maybeInstant = instantActionConfigurationPanel.getAction();
-    if (maybeInstant.isPresent()) {
-      Action action = maybeInstant.get();
-      if (!validateInitPositionNumericParams(action)) {
-        return;
+    try {
+      Optional<Action> maybeInstant = instantActionConfigurationPanel.getAction();
+      if (maybeInstant.isPresent()) {
+        Action action = maybeInstant.get();
+
+        validateParameters(action);
+
+        Map<String, String> messageParameters = new HashMap<>();
+
+        messageParameters.put(
+            CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_TYPE,
+            action.getActionType()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_ID,
+            action.getActionId()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE,
+            action.getBlockingType().name()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_DESCRIPTION,
+            action.getActionDescription()
+        );
+
+        action.getActionParameters()
+            .forEach(
+                actionParameter -> messageParameters.put(
+                    CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX
+                        + actionParameter.getKey(),
+                    actionParameter.getValue().toString()
+                )
+            );
+
+        sendAdapterMessage(
+            new VehicleCommAdapterMessage(
+                CommAdapterMessages.SEND_INSTANT_ACTION_TYPE, messageParameters
+            )
+        );
       }
-
-      Map<String, String> messageParameters = new HashMap<>();
-
-      messageParameters.put(
-          CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_TYPE,
-          action.getActionType()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_ID,
-          action.getActionId()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE,
-          action.getBlockingType().name()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_DESCRIPTION,
-          action.getActionDescription()
-      );
-
-      action.getActionParameters()
-          .forEach(
-              actionParameter -> messageParameters.put(
-                  CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX
-                      + actionParameter.getKey(),
-                  actionParameter.getValue().toString()
-              )
-          );
-
-      sendAdapterMessage(
-          new VehicleCommAdapterMessage(
-              CommAdapterMessages.SEND_INSTANT_ACTION_TYPE, messageParameters
-          )
+    }
+    catch (InvalidActionParameterException ex) {
+      JOptionPane.showMessageDialog(
+          this,
+          ex.getMessage(),
+          "Invalid action parameter",
+          JOptionPane.ERROR_MESSAGE
       );
     }
   }//GEN-LAST:event_sendInstantActionButtonActionPerformed
@@ -844,46 +862,67 @@ public class ControlPanel
   }
 
   /**
-   * Validates that x, y, and theta parameters of an initPosition action are valid finite numbers.
-   * Shows an error dialog and returns false if any are invalid.
+   * Validates the parameters of the given action.
    *
-   * @return true if validation passes (or action is not initPosition), false otherwise.
+   * @param action The action
+   * @throws InvalidActionParameterException If any parameters of the given action are not valid.
    */
-  private boolean validateInitPositionNumericParams(Action action) {
-    if (!InitPosition.ACTION_TYPE.equals(action.getActionType())) {
-      return true;
+  private void validateParameters(Action action)
+      throws InvalidActionParameterException {
+    if (Objects.equals(action.getActionType(), InitPosition.ACTION_TYPE)) {
+      validateInitPositionNumericParams(action);
+    }
+  }
+
+  /**
+   * Validates that x, y, and theta parameters of an initPosition action are valid finite numbers.
+   *
+   * @param action The action.
+   * @throws InvalidActionParameterException If any parameter is not a valid finite number.
+   */
+  private void validateInitPositionNumericParams(Action action)
+      throws InvalidActionParameterException {
+    if (!Objects.equals(action.getActionType(), InitPosition.ACTION_TYPE)) {
+      return;
     }
 
-    for (var ap : action.getActionParameters()) {
-      if (!InitPosition.PARAMKEY_X.equals(ap.getKey())
-          && !InitPosition.PARAMKEY_Y.equals(ap.getKey())
-          && !InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
-        continue;
-      }
+    Optional<ActionParameter> mistypedParameter = action.getActionParameters().stream()
+        .filter(
+            parameter -> Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_X)
+                || Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_Y)
+                || Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_THETA)
+        )
+        .filter(parameter -> parameter.getValue() instanceof String)
+        .filter(parameter -> {
+          try {
+            return !Double.isFinite(Double.parseDouble((String) parameter.getValue()));
+          }
+          catch (NumberFormatException e) {
+            return true;
+          }
+        })
+        .findAny();
 
-      Object v = ap.getValue();
-      if (v instanceof Number) {
-        continue;
-      }
-
-      try {
-        double parsed = Double.parseDouble(String.valueOf(v));
-        if (!Double.isFinite(parsed)) {
-          throw new NumberFormatException("Non-finite value: " + v);
-        }
-      }
-      catch (NumberFormatException ex) {
-        JOptionPane.showMessageDialog(
-            this,
-            "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
-            "Invalid parameter",
-            JOptionPane.ERROR_MESSAGE
-        );
-        return false;
-      }
+    if (mistypedParameter.isPresent()) {
+      ActionParameter parameter = mistypedParameter.get();
+      throw new IllegalArgumentException(
+          "Parameter '%s': value '%s' is not a floating-point number"
+              .formatted(
+                  parameter.getKey(),
+                  parameter.getValue()
+              )
+      );
     }
+  }
 
-    return true;
+  /**
+   * Indicates an invalid action parameter.
+   */
+  private static class InvalidActionParameterException
+      extends RuntimeException {
+    public InvalidActionParameterException(String message) {
+      super(message);
+    }
   }
 
   // FORMATTER:OFF

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
@@ -905,7 +905,7 @@ public class ControlPanel
 
     if (mistypedParameter.isPresent()) {
       ActionParameter parameter = mistypedParameter.get();
-      throw new IllegalArgumentException(
+      throw new InvalidActionParameterException(
           "Parameter '%s': value '%s' is not a floating-point number"
               .formatted(
                   parameter.getKey(),

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
@@ -921,7 +921,7 @@ public class ControlPanel
   private static class InvalidActionParameterException
       extends
         RuntimeException {
-    public InvalidActionParameterException(String message) {
+    InvalidActionParameterException(String message) {
       super(message);
     }
   }

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/controlcenter/ControlPanel.java
@@ -919,7 +919,8 @@ public class ControlPanel
    * Indicates an invalid action parameter.
    */
   private static class InvalidActionParameterException
-      extends RuntimeException {
+      extends
+        RuntimeException {
     public InvalidActionParameterException(String message) {
       super(message);
     }

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
@@ -239,17 +239,20 @@ public class CommAdapterMessageMapper {
   private Object parseParameterValue(String actionType, String paramKey, String value) {
     // Only parse numeric parameters for well-known action types/keys. Prevent accidental
     // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
-    try {
-      if (InitPosition.ACTION_TYPE.equals(actionType)) {
-        if (InitPosition.PARAMKEY_X.equals(paramKey)
+    if (InitPosition.ACTION_TYPE.equals(actionType)
+        && (InitPosition.PARAMKEY_X.equals(paramKey)
             || InitPosition.PARAMKEY_Y.equals(paramKey)
-            || InitPosition.PARAMKEY_THETA.equals(paramKey)) {
-          return Double.parseDouble(value);
+            || InitPosition.PARAMKEY_THETA.equals(paramKey))) {
+      try {
+        double parsed = Double.parseDouble(value);
+        if (!Double.isFinite(parsed)) {
+          throw new NumberFormatException("Non-finite double: " + value);
         }
+        return parsed;
       }
-    }
-    catch (NumberFormatException e) {
-      // fall through to return the original string
+      catch (NumberFormatException e) {
+        // fall through to return the original string
+      }
     }
 
     return value;

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
@@ -243,10 +243,10 @@ public class CommAdapterMessageMapper {
   private Optional<Object> parseParameterValue(String actionType, String paramKey, String value) {
     // Only parse numeric parameters for well-known action types/keys. Prevent accidental
     // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
-    if (InitPosition.ACTION_TYPE.equals(actionType)
-        && (InitPosition.PARAMKEY_X.equals(paramKey)
-            || InitPosition.PARAMKEY_Y.equals(paramKey)
-            || InitPosition.PARAMKEY_THETA.equals(paramKey))) {
+    if (Objects.equals(actionType, InitPosition.ACTION_TYPE)
+        && (Objects.equals(paramKey, InitPosition.PARAMKEY_X)
+            || Objects.equals(paramKey, InitPosition.PARAMKEY_Y)
+            || Objects.equals(paramKey, InitPosition.PARAMKEY_THETA))) {
       try {
         double parsed = Double.parseDouble(value);
         if (!Double.isFinite(parsed)) {

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
@@ -17,6 +17,7 @@ import static org.opentcs.commadapter.vehicle.vda5050.v2_0.CommAdapterMessages.S
 
 import com.google.inject.assistedinject.Assisted;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -110,16 +111,22 @@ public class CommAdapterMessageMapper {
         destinationNodeName.get(),
         1
     );
-    toAction(
+    boolean actionRequested = mapValueExtractor.extractString(
+        SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
+        message.getParameters()
+    ).isPresent();
+    Optional<Action> action = toAction(
         message.getParameters(),
         SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
         SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_ID,
         SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_DESCRIPTION,
         SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_BLOCKING_TYPE,
         SEND_ORDER_PARAM_PARAMETER_PATTERN
-    ).ifPresent(action -> {
-      destinationNode.setActions(List.of(action));
-    });
+    );
+    if (actionRequested && action.isEmpty()) {
+      return Optional.empty();
+    }
+    action.ifPresent(a -> destinationNode.setActions(List.of(a)));
 
     Edge edge = createEdge(
         edgeName.get(),
@@ -196,27 +203,24 @@ public class CommAdapterMessageMapper {
     );
 
     actionDescription.ifPresent(action::setActionDescription);
-    record ParameterMatcher(Map.Entry<String, String> parameter, Matcher matcher) {}
-    action.setActionParameters(
-        messageParameters.entrySet().stream()
-            .map(
-                entry -> new ParameterMatcher(
-                    entry,
-                    actionParameterPattern.matcher(entry.getKey())
-                )
-            )
-            .filter(parameterMatcher -> parameterMatcher.matcher.matches())
-            .map(
-                parameterMatcher -> new ActionParameter(
-                    parameterMatcher.matcher.group(1),
-                    parseParameterValue(
-                        action.getActionType(), parameterMatcher.matcher.group(1),
-                        parameterMatcher.parameter.getValue()
-                    )
-                )
-            )
-            .toList()
-    );
+
+    List<ActionParameter> actionParameters = new ArrayList<>();
+    for (Map.Entry<String, String> entry : messageParameters.entrySet()) {
+      Matcher matcher = actionParameterPattern.matcher(entry.getKey());
+      if (!matcher.matches()) {
+        continue;
+      }
+
+      String paramKey = matcher.group(1);
+      Optional<Object> parsedValue = parseParameterValue(
+          action.getActionType(), paramKey, entry.getValue()
+      );
+      if (parsedValue.isEmpty()) {
+        return Optional.empty();
+      }
+      actionParameters.add(new ActionParameter(paramKey, parsedValue.get()));
+    }
+    action.setActionParameters(actionParameters);
 
     return Optional.of(action);
   }
@@ -236,7 +240,7 @@ public class CommAdapterMessageMapper {
     );
   }
 
-  private Object parseParameterValue(String actionType, String paramKey, String value) {
+  private Optional<Object> parseParameterValue(String actionType, String paramKey, String value) {
     // Only parse numeric parameters for well-known action types/keys. Prevent accidental
     // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
     if (InitPosition.ACTION_TYPE.equals(actionType)
@@ -246,16 +250,16 @@ public class CommAdapterMessageMapper {
       try {
         double parsed = Double.parseDouble(value);
         if (!Double.isFinite(parsed)) {
-          throw new NumberFormatException("Non-finite double: " + value);
+          return Optional.empty();
         }
-        return parsed;
+        return Optional.of(parsed);
       }
       catch (NumberFormatException e) {
-        // fall through to return the original string
+        return Optional.empty();
       }
     }
 
-    return value;
+    return Optional.of(value);
   }
 
   private Edge createEdge(String pathName, String startNodeId, String endNodeId) {

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
@@ -240,6 +240,17 @@ public class CommAdapterMessageMapper {
     );
   }
 
+  private Edge createEdge(String pathName, String startNodeId, String endNodeId) {
+    return new Edge(
+        pathName,
+        0L,
+        true,
+        startNodeId,
+        endNodeId,
+        List.of()
+    );
+  }
+
   private Optional<Object> parseParameterValue(String actionType, String paramKey, String value) {
     // Only parse numeric parameters for well-known action types/keys. Prevent accidental
     // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
@@ -260,16 +271,5 @@ public class CommAdapterMessageMapper {
     }
 
     return Optional.of(value);
-  }
-
-  private Edge createEdge(String pathName, String startNodeId, String endNodeId) {
-    return new Edge(
-        pathName,
-        0L,
-        true,
-        startNodeId,
-        endNodeId,
-        List.of()
-    );
   }
 }

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
@@ -35,6 +35,7 @@ import org.opentcs.data.model.Point;
 import org.opentcs.data.model.Vehicle;
 import org.opentcs.drivers.vehicle.VehicleCommAdapterMessage;
 import org.opentcs.util.MapValueExtractor;
+import org.opentcs.commadapter.vehicle.vda5050.v2_0.action.InitPosition;
 
 /**
  * Provide methods for mapping {@link VehicleCommAdapterMessage}s to other types.
@@ -208,7 +209,7 @@ public class CommAdapterMessageMapper {
             .map(
                 parameterMatcher -> new ActionParameter(
                     parameterMatcher.matcher.group(1),
-                    parameterMatcher.parameter.getValue()
+                    parseParameterValue(action.getActionType(), parameterMatcher.matcher.group(1), parameterMatcher.parameter.getValue())
                 )
             )
             .toList()

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.opentcs.commadapter.vehicle.vda5050.v2_0.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.BlockingType;
@@ -35,7 +36,6 @@ import org.opentcs.data.model.Point;
 import org.opentcs.data.model.Vehicle;
 import org.opentcs.drivers.vehicle.VehicleCommAdapterMessage;
 import org.opentcs.util.MapValueExtractor;
-import org.opentcs.commadapter.vehicle.vda5050.v2_0.action.InitPosition;
 
 /**
  * Provide methods for mapping {@link VehicleCommAdapterMessage}s to other types.
@@ -209,7 +209,10 @@ public class CommAdapterMessageMapper {
             .map(
                 parameterMatcher -> new ActionParameter(
                     parameterMatcher.matcher.group(1),
-                    parseParameterValue(action.getActionType(), parameterMatcher.matcher.group(1), parameterMatcher.parameter.getValue())
+                    parseParameterValue(
+                        action.getActionType(), parameterMatcher.matcher.group(1),
+                        parameterMatcher.parameter.getValue()
+                    )
                 )
             )
             .toList()
@@ -232,6 +235,7 @@ public class CommAdapterMessageMapper {
         )
     );
   }
+
   private Object parseParameterValue(String actionType, String paramKey, String value) {
     // Only parse numeric parameters for well-known action types/keys. Prevent accidental
     // conversion of string fields that just look like numbers (e.g., mapId = "1.0").

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapper.java
@@ -231,6 +231,24 @@ public class CommAdapterMessageMapper {
         )
     );
   }
+  private Object parseParameterValue(String actionType, String paramKey, String value) {
+    // Only parse numeric parameters for well-known action types/keys. Prevent accidental
+    // conversion of string fields that just look like numbers (e.g., mapId = "1.0").
+    try {
+      if (InitPosition.ACTION_TYPE.equals(actionType)) {
+        if (InitPosition.PARAMKEY_X.equals(paramKey)
+            || InitPosition.PARAMKEY_Y.equals(paramKey)
+            || InitPosition.PARAMKEY_THETA.equals(paramKey)) {
+          return Double.parseDouble(value);
+        }
+      }
+    }
+    catch (NumberFormatException e) {
+      // fall through to return the original string
+    }
+
+    return value;
+  }
 
   private Edge createEdge(String pathName, String startNodeId, String endNodeId) {
     return new Edge(

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -701,32 +701,8 @@ public class ControlPanel
     if (maybeAction.isPresent()) {
       Action action = maybeAction.get();
 
-      // Validate numeric parameters for initPosition action
-      if (InitPosition.ACTION_TYPE.equals(action.getActionType())) {
-        for (var ap : action.getActionParameters()) {
-          if (InitPosition.PARAMKEY_X.equals(ap.getKey())
-              || InitPosition.PARAMKEY_Y.equals(ap.getKey())
-              || InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
-            Object v = ap.getValue();
-            if (!(v instanceof Number)) {
-              try {
-                double parsed = Double.parseDouble(String.valueOf(v));
-                if (!Double.isFinite(parsed)) {
-                  throw new NumberFormatException("Non-finite double: " + v);
-                }
-              }
-              catch (NumberFormatException ex) {
-                JOptionPane.showMessageDialog(
-                    this,
-                    "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
-                    "Invalid parameter",
-                    JOptionPane.ERROR_MESSAGE
-                );
-                return;
-              }
-            }
-          }
-        }
+      if (!validateInitPositionNumericParams(action)) {
+        return;
       }
 
       messageParameters.put(
@@ -770,32 +746,8 @@ public class ControlPanel
     if (maybeInstant.isPresent()) {
       Action action = maybeInstant.get();
 
-      // Validate numeric parameters for initPosition action
-      if (InitPosition.ACTION_TYPE.equals(action.getActionType())) {
-        for (var ap : action.getActionParameters()) {
-          if (InitPosition.PARAMKEY_X.equals(ap.getKey())
-              || InitPosition.PARAMKEY_Y.equals(ap.getKey())
-              || InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
-            Object v = ap.getValue();
-            if (!(v instanceof Number)) {
-              try {
-                double parsed = Double.parseDouble(String.valueOf(v));
-                if (!Double.isFinite(parsed)) {
-                  throw new NumberFormatException("Non-finite double: " + v);
-                }
-              }
-              catch (NumberFormatException ex) {
-                JOptionPane.showMessageDialog(
-                    this,
-                    "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
-                    "Invalid parameter",
-                    JOptionPane.ERROR_MESSAGE
-                );
-                return;
-              }
-            }
-          }
-        }
+      if (!validateInitPositionNumericParams(action)) {
+        return;
       }
 
       Map<String, String> messageParameters = new HashMap<>();
@@ -901,6 +853,46 @@ public class ControlPanel
 
   // FORMATTER:OFF
   // CHECKSTYLE:OFF
+  /**
+   * Validates that x, y, and theta parameters of an initPosition action are valid finite numbers.
+   * Shows an error dialog and returns false if any are invalid.
+   *
+   * @return true if validation passes (or action is not initPosition), false otherwise.
+   */
+  private boolean validateInitPositionNumericParams(Action action) {
+    if (!InitPosition.ACTION_TYPE.equals(action.getActionType())) {
+      return true;
+    }
+
+    for (var ap : action.getActionParameters()) {
+      if (!InitPosition.PARAMKEY_X.equals(ap.getKey())
+          && !InitPosition.PARAMKEY_Y.equals(ap.getKey())
+          && !InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
+        continue;
+      }
+
+      Object v = ap.getValue();
+      if (v instanceof Number) {
+        continue;
+      }
+
+      try {
+        Double.parseDouble(String.valueOf(v));
+      }
+      catch (NumberFormatException ex) {
+        JOptionPane.showMessageDialog(
+            this,
+            "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
+            "Invalid parameter",
+            JOptionPane.ERROR_MESSAGE
+        );
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   // Variables declaration - do not modify//GEN-BEGIN:variables
   private javax.swing.JButton applyLastInstantActionButton;
   private javax.swing.JButton applyLastOrderButton;

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -710,7 +710,10 @@ public class ControlPanel
             Object v = ap.getValue();
             if (!(v instanceof Number)) {
               try {
-                Double.parseDouble(String.valueOf(v));
+                double parsed = Double.parseDouble(String.valueOf(v));
+                if (!Double.isFinite(parsed)) {
+                  throw new NumberFormatException("Non-finite double: " + v);
+                }
               }
               catch (NumberFormatException ex) {
                 JOptionPane.showMessageDialog(
@@ -776,7 +779,10 @@ public class ControlPanel
             Object v = ap.getValue();
             if (!(v instanceof Number)) {
               try {
-                Double.parseDouble(String.valueOf(v));
+                double parsed = Double.parseDouble(String.valueOf(v));
+                if (!Double.isFinite(parsed)) {
+                  throw new NumberFormatException("Non-finite double: " + v);
+                }
               }
               catch (NumberFormatException ex) {
                 JOptionPane.showMessageDialog(

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -18,6 +18,7 @@ import org.opentcs.commadapter.vehicle.vda5050.v2_0.ProcessModelImpl;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.controlcenter.action.ActionConfigurationPanel;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action;
+import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.instantactions.InstantActions;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.order.Node;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.order.Order;
@@ -697,44 +698,52 @@ public class ControlPanel
         path.getName()
     );
 
-    Optional<Action> maybeAction = newOrderActionConfigurationPanel.getAction();
-    if (maybeAction.isPresent()) {
-      Action action = maybeAction.get();
+    try {
+      Optional<Action> maybeAction = newOrderActionConfigurationPanel.getAction();
+      if (maybeAction.isPresent()) {
+        Action action = maybeAction.get();
 
-      if (!validateInitPositionNumericParams(action)) {
-        return;
+        validateParameters(action);
+
+        messageParameters.put(
+            CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
+            action.getActionType()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_ID,
+            action.getActionId()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_BLOCKING_TYPE,
+            action.getBlockingType().name()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_DESCRIPTION,
+            action.getActionDescription()
+        );
+
+
+        action.getActionParameters().forEach(
+            actionParameter -> messageParameters.put(
+                CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_PARAMETER_PREFIX
+                    + actionParameter.getKey(),
+                actionParameter.getValue().toString()
+            )
+        );
       }
 
-      messageParameters.put(
-          CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
-          action.getActionType()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_ID,
-          action.getActionId()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_BLOCKING_TYPE,
-          action.getBlockingType().name()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_DESCRIPTION,
-          action.getActionDescription()
-      );
-
-
-      action.getActionParameters().forEach(
-          actionParameter -> messageParameters.put(
-              CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_PARAMETER_PREFIX
-                  + actionParameter.getKey(),
-              actionParameter.getValue().toString()
-          )
+      sendAdapterMessage(
+          new VehicleCommAdapterMessage(CommAdapterMessages.SEND_ORDER_TYPE, messageParameters)
       );
     }
-
-    sendAdapterMessage(
-        new VehicleCommAdapterMessage(CommAdapterMessages.SEND_ORDER_TYPE, messageParameters)
-    );
+    catch (InvalidActionParameterException ex) {
+      JOptionPane.showMessageDialog(
+          this,
+          ex.getMessage(),
+          "Invalid parameter",
+          JOptionPane.ERROR_MESSAGE
+      );
+    }
   }//GEN-LAST:event_sendOrderButtonActionPerformed
 
   private void enableAdapterCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_enableAdapterCheckBoxActionPerformed
@@ -742,45 +751,53 @@ public class ControlPanel
   }//GEN-LAST:event_enableAdapterCheckBoxActionPerformed
 
   private void sendInstantActionButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_sendInstantActionButtonActionPerformed
-    Optional<Action> maybeInstant = instantActionConfigurationPanel.getAction();
-    if (maybeInstant.isPresent()) {
-      Action action = maybeInstant.get();
-      if (!validateInitPositionNumericParams(action)) {
-        return;
+    try {
+      Optional<Action> maybeInstant = instantActionConfigurationPanel.getAction();
+      if (maybeInstant.isPresent()) {
+        Action action = maybeInstant.get();
+        validateParameters(action);
+
+        Map<String, String> messageParameters = new HashMap<>();
+
+        messageParameters.put(
+            CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_TYPE,
+            action.getActionType()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_ID,
+            action.getActionId()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE,
+            action.getBlockingType().name()
+        );
+        messageParameters.put(
+            CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_DESCRIPTION,
+            action.getActionDescription()
+        );
+
+        action.getActionParameters()
+            .forEach(
+                actionParameter -> messageParameters.put(
+                    CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX
+                        + actionParameter.getKey(),
+                    actionParameter.getValue().toString()
+                )
+            );
+
+        sendAdapterMessage(
+            new VehicleCommAdapterMessage(
+                CommAdapterMessages.SEND_INSTANT_ACTION_TYPE, messageParameters
+            )
+        );
       }
-
-      Map<String, String> messageParameters = new HashMap<>();
-
-      messageParameters.put(
-          CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_TYPE,
-          action.getActionType()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_ID,
-          action.getActionId()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE,
-          action.getBlockingType().name()
-      );
-      messageParameters.put(
-          CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_ACTION_DESCRIPTION,
-          action.getActionDescription()
-      );
-
-      action.getActionParameters()
-          .forEach(
-              actionParameter -> messageParameters.put(
-                  CommAdapterMessages.SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX
-                      + actionParameter.getKey(),
-                  actionParameter.getValue().toString()
-              )
-          );
-
-      sendAdapterMessage(
-          new VehicleCommAdapterMessage(
-              CommAdapterMessages.SEND_INSTANT_ACTION_TYPE, messageParameters
-          )
+    }
+    catch (InvalidActionParameterException ex) {
+      JOptionPane.showMessageDialog(
+          this,
+          ex.getMessage(),
+          "Invalid action parameter",
+          JOptionPane.ERROR_MESSAGE
       );
     }
   }//GEN-LAST:event_sendInstantActionButtonActionPerformed
@@ -851,46 +868,97 @@ public class ControlPanel
   }
 
   /**
-   * Validates that x, y, and theta parameters of an initPosition action are valid finite numbers.
-   * Shows an error dialog and returns false if any are invalid.
+   * Validates the parameters of the given action.
    *
-   * @return true if validation passes (or action is not initPosition), false otherwise.
+   * @param action The action
+   * @throws InvalidActionParameterException If any parameters of the given action are not valid.
    */
-  private boolean validateInitPositionNumericParams(Action action) {
-    if (!InitPosition.ACTION_TYPE.equals(action.getActionType())) {
-      return true;
+  private void validateParameters(Action action)
+      throws InvalidActionParameterException {
+    if (Objects.equals(action.getActionType(), InitPosition.ACTION_TYPE)) {
+      validateInitPositionNumericParams(action);
+    }
+  }
+
+  /**
+   * Validates that x, y, and theta parameters of an initPosition action are valid finite numbers.
+   *
+   * @param action The action.
+   * @throws InvalidActionParameterException If any parameter is not a valid finite number.
+   */
+  private void validateInitPositionNumericParams(Action action) {
+    if (!Objects.equals(action.getActionType(), InitPosition.ACTION_TYPE)) {
+      return;
     }
 
-    for (var ap : action.getActionParameters()) {
-      if (!InitPosition.PARAMKEY_X.equals(ap.getKey())
-          && !InitPosition.PARAMKEY_Y.equals(ap.getKey())
-          && !InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
-        continue;
-      }
+    Optional<ActionParameter> mistypedParameter = action.getActionParameters().stream()
+        .filter(parameter -> Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_X)
+            || Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_Y)
+            || Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_THETA)
+        )
+        .filter(parameter -> parameter.getValue() instanceof String)
+        .filter(parameter -> {
+          try {
+            return !Double.isFinite(Double.parseDouble((String) parameter.getValue()));
+          }
+          catch (NumberFormatException e) {
+            return true;
+          }
+        })
+        .findAny();
 
-      Object v = ap.getValue();
-      if (v instanceof Number) {
-        continue;
-      }
-
-      try {
-        double parsed = Double.parseDouble(String.valueOf(v));
-        if (!Double.isFinite(parsed)) {
-          throw new NumberFormatException("Non-finite value: " + v);
-        }
-      }
-      catch (NumberFormatException ex) {
-        JOptionPane.showMessageDialog(
-            this,
-            "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
-            "Invalid parameter",
-            JOptionPane.ERROR_MESSAGE
-        );
-        return false;
-      }
+    if (mistypedParameter.isPresent()) {
+      ActionParameter parameter = mistypedParameter.get();
+      throw new InvalidActionParameterException(
+          "Parameter '%s': value '%s' is not a floating-point number"
+              .formatted(
+                  parameter.getKey(),
+                  parameter.getValue()
+              )
+      );
     }
+//
+//    for (ActionParameter ap : action.getActionParameters()) {
+//      if (!InitPosition.PARAMKEY_X.equals(ap.getKey())
+//          && !InitPosition.PARAMKEY_Y.equals(ap.getKey())
+//          && !InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
+//        continue;
+//      }
+//
+//      Object v = ap.getValue();
+//      if (v instanceof Number) {
+//        continue;
+//      }
+//
+//      try {
+//        double parsed = Double.parseDouble(String.valueOf(v));
+//        if (!Double.isFinite(parsed)) {
+//          throw new NumberFormatException("Non-finite value: " + v);
+//        }
+//      }
+//      catch (NumberFormatException ex) {
+//        JOptionPane.showMessageDialog(
+//            this,
+//            "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
+//            "Invalid parameter",
+//            JOptionPane.ERROR_MESSAGE
+//        );
+//        return false;
+//      }
+//    }
+//
+//    return true;
+  }
 
-    return true;
+
+  /**
+   * Indicates an invalid action parameter.
+   */
+  private static class InvalidActionParameterException
+      extends RuntimeException {
+    public InvalidActionParameterException(String message) {
+      super(message);
+    }
   }
 
   // FORMATTER:OFF

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -17,6 +17,7 @@ import org.opentcs.commadapter.vehicle.vda5050.v2_0.CommAdapterMessages;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.ProcessModelImpl;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.controlcenter.action.ActionConfigurationPanel;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action;
+import org.opentcs.commadapter.vehicle.vda5050.v2_0.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.instantactions.InstantActions;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.order.Node;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.order.Order;
@@ -696,7 +697,37 @@ public class ControlPanel
         path.getName()
     );
 
-    newOrderActionConfigurationPanel.getAction().ifPresent(action -> {
+    Optional<org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action> maybeAction
+        = newOrderActionConfigurationPanel.getAction();
+    if (maybeAction.isPresent()) {
+      org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action action = maybeAction.get();
+
+      // Validate numeric parameters for initPosition action
+      if (InitPosition.ACTION_TYPE.equals(action.getActionType())) {
+        for (org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter ap
+            : action.getActionParameters()) {
+          if (InitPosition.PARAMKEY_X.equals(ap.getKey())
+              || InitPosition.PARAMKEY_Y.equals(ap.getKey())
+              || InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
+            Object v = ap.getValue();
+            if (!(v instanceof Number)) {
+              try {
+                Double.parseDouble(String.valueOf(v));
+              }
+              catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(
+                    this,
+                    "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
+                    "Invalid parameter",
+                    JOptionPane.ERROR_MESSAGE
+                );
+                return;
+              }
+            }
+          }
+        }
+      }
+
       messageParameters.put(
           CommAdapterMessages.SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE,
           action.getActionType()
@@ -722,7 +753,7 @@ public class ControlPanel
               actionParameter.getValue().toString()
           )
       );
-    });
+    }
 
     sendAdapterMessage(
         new VehicleCommAdapterMessage(CommAdapterMessages.SEND_ORDER_TYPE, messageParameters)
@@ -734,7 +765,37 @@ public class ControlPanel
   }//GEN-LAST:event_enableAdapterCheckBoxActionPerformed
 
   private void sendInstantActionButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_sendInstantActionButtonActionPerformed
-    instantActionConfigurationPanel.getAction().ifPresent(action -> {
+    Optional<org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action> maybeInstant
+        = instantActionConfigurationPanel.getAction();
+    if (maybeInstant.isPresent()) {
+      org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action action = maybeInstant.get();
+
+      // Validate numeric parameters for initPosition action
+      if (InitPosition.ACTION_TYPE.equals(action.getActionType())) {
+        for (org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter ap
+            : action.getActionParameters()) {
+          if (InitPosition.PARAMKEY_X.equals(ap.getKey())
+              || InitPosition.PARAMKEY_Y.equals(ap.getKey())
+              || InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
+            Object v = ap.getValue();
+            if (!(v instanceof Number)) {
+              try {
+                Double.parseDouble(String.valueOf(v));
+              }
+              catch (NumberFormatException ex) {
+                JOptionPane.showMessageDialog(
+                    this,
+                    "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
+                    "Invalid parameter",
+                    JOptionPane.ERROR_MESSAGE
+                );
+                return;
+              }
+            }
+          }
+        }
+      }
+
       Map<String, String> messageParameters = new HashMap<>();
 
       messageParameters.put(
@@ -768,7 +829,7 @@ public class ControlPanel
               CommAdapterMessages.SEND_INSTANT_ACTION_TYPE, messageParameters
           )
       );
-    });
+    }
   }//GEN-LAST:event_sendInstantActionButtonActionPerformed
 
   private void applyLastOrderButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_applyLastOrderButtonActionPerformed

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -697,15 +697,13 @@ public class ControlPanel
         path.getName()
     );
 
-    Optional<org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action> maybeAction
-        = newOrderActionConfigurationPanel.getAction();
+    Optional<Action> maybeAction = newOrderActionConfigurationPanel.getAction();
     if (maybeAction.isPresent()) {
-      org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action action = maybeAction.get();
+      Action action = maybeAction.get();
 
       // Validate numeric parameters for initPosition action
       if (InitPosition.ACTION_TYPE.equals(action.getActionType())) {
-        for (org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter ap : action
-            .getActionParameters()) {
+        for (var ap : action.getActionParameters()) {
           if (InitPosition.PARAMKEY_X.equals(ap.getKey())
               || InitPosition.PARAMKEY_Y.equals(ap.getKey())
               || InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
@@ -765,16 +763,13 @@ public class ControlPanel
   }//GEN-LAST:event_enableAdapterCheckBoxActionPerformed
 
   private void sendInstantActionButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_sendInstantActionButtonActionPerformed
-    Optional<org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action> maybeInstant
-        = instantActionConfigurationPanel.getAction();
+    Optional<Action> maybeInstant = instantActionConfigurationPanel.getAction();
     if (maybeInstant.isPresent()) {
-      org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action action = maybeInstant
-          .get();
+      Action action = maybeInstant.get();
 
       // Validate numeric parameters for initPosition action
       if (InitPosition.ACTION_TYPE.equals(action.getActionType())) {
-        for (org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter ap : action
-            .getActionParameters()) {
+        for (var ap : action.getActionParameters()) {
           if (InitPosition.PARAMKEY_X.equals(ap.getKey())
               || InitPosition.PARAMKEY_Y.equals(ap.getKey())
               || InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -874,7 +874,10 @@ public class ControlPanel
       }
 
       try {
-        Double.parseDouble(String.valueOf(v));
+        double parsed = Double.parseDouble(String.valueOf(v));
+        if (!Double.isFinite(parsed)) {
+          throw new NumberFormatException("Non-finite value: " + v);
+        }
       }
       catch (NumberFormatException ex) {
         JOptionPane.showMessageDialog(

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -15,9 +15,9 @@ import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.CommAdapterMessages;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.ProcessModelImpl;
+import org.opentcs.commadapter.vehicle.vda5050.v2_0.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.controlcenter.action.ActionConfigurationPanel;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action;
-import org.opentcs.commadapter.vehicle.vda5050.v2_0.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.instantactions.InstantActions;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.order.Node;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.order.Order;
@@ -704,8 +704,8 @@ public class ControlPanel
 
       // Validate numeric parameters for initPosition action
       if (InitPosition.ACTION_TYPE.equals(action.getActionType())) {
-        for (org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter ap
-            : action.getActionParameters()) {
+        for (org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter ap : action
+            .getActionParameters()) {
           if (InitPosition.PARAMKEY_X.equals(ap.getKey())
               || InitPosition.PARAMKEY_Y.equals(ap.getKey())
               || InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
@@ -768,12 +768,13 @@ public class ControlPanel
     Optional<org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action> maybeInstant
         = instantActionConfigurationPanel.getAction();
     if (maybeInstant.isPresent()) {
-      org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action action = maybeInstant.get();
+      org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action action = maybeInstant
+          .get();
 
       // Validate numeric parameters for initPosition action
       if (InitPosition.ACTION_TYPE.equals(action.getActionType())) {
-        for (org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter ap
-            : action.getActionParameters()) {
+        for (org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter ap : action
+            .getActionParameters()) {
           if (InitPosition.PARAMKEY_X.equals(ap.getKey())
               || InitPosition.PARAMKEY_Y.equals(ap.getKey())
               || InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -745,7 +745,6 @@ public class ControlPanel
     Optional<Action> maybeInstant = instantActionConfigurationPanel.getAction();
     if (maybeInstant.isPresent()) {
       Action action = maybeInstant.get();
-
       if (!validateInitPositionNumericParams(action)) {
         return;
       }
@@ -851,8 +850,6 @@ public class ControlPanel
     return Optional.of(lastNode.getActions().get(0));
   }
 
-  // FORMATTER:OFF
-  // CHECKSTYLE:OFF
   /**
    * Validates that x, y, and theta parameters of an initPosition action are valid finite numbers.
    * Shows an error dialog and returns false if any are invalid.
@@ -893,6 +890,8 @@ public class ControlPanel
     return true;
   }
 
+  // FORMATTER:OFF
+  // CHECKSTYLE:OFF
   // Variables declaration - do not modify//GEN-BEGIN:variables
   private javax.swing.JButton applyLastInstantActionButton;
   private javax.swing.JButton applyLastOrderButton;

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -918,37 +918,6 @@ public class ControlPanel
               )
       );
     }
-//
-//    for (ActionParameter ap : action.getActionParameters()) {
-//      if (!InitPosition.PARAMKEY_X.equals(ap.getKey())
-//          && !InitPosition.PARAMKEY_Y.equals(ap.getKey())
-//          && !InitPosition.PARAMKEY_THETA.equals(ap.getKey())) {
-//        continue;
-//      }
-//
-//      Object v = ap.getValue();
-//      if (v instanceof Number) {
-//        continue;
-//      }
-//
-//      try {
-//        double parsed = Double.parseDouble(String.valueOf(v));
-//        if (!Double.isFinite(parsed)) {
-//          throw new NumberFormatException("Non-finite value: " + v);
-//        }
-//      }
-//      catch (NumberFormatException ex) {
-//        JOptionPane.showMessageDialog(
-//            this,
-//            "Parameter '" + ap.getKey() + "' must be a valid floating point number.",
-//            "Invalid parameter",
-//            JOptionPane.ERROR_MESSAGE
-//        );
-//        return false;
-//      }
-//    }
-//
-//    return true;
   }
 
 
@@ -958,7 +927,7 @@ public class ControlPanel
   private static class InvalidActionParameterException
       extends
         RuntimeException {
-    public InvalidActionParameterException(String message) {
+    InvalidActionParameterException(String message) {
       super(message);
     }
   }

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/controlcenter/ControlPanel.java
@@ -892,9 +892,10 @@ public class ControlPanel
     }
 
     Optional<ActionParameter> mistypedParameter = action.getActionParameters().stream()
-        .filter(parameter -> Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_X)
-            || Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_Y)
-            || Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_THETA)
+        .filter(
+            parameter -> Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_X)
+                || Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_Y)
+                || Objects.equals(parameter.getKey(), InitPosition.PARAMKEY_THETA)
         )
         .filter(parameter -> parameter.getValue() instanceof String)
         .filter(parameter -> {
@@ -955,7 +956,8 @@ public class ControlPanel
    * Indicates an invalid action parameter.
    */
   private static class InvalidActionParameterException
-      extends RuntimeException {
+      extends
+        RuntimeException {
     public InvalidActionParameterException(String message) {
       super(message);
     }

--- a/src/test/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/CommAdapterMessageMapperTest.java
+++ b/src/test/java/org/opentcs/commadapter/vehicle/vda5050/v1_1/CommAdapterMessageMapperTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentcs.commadapter.vehicle.vda5050.v1_1.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.Action;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.ActionParameter;
 import org.opentcs.commadapter.vehicle.vda5050.v1_1.message.common.BlockingType;
@@ -153,5 +154,125 @@ class CommAdapterMessageMapperTest {
                   tuple("action-param-2", "value-2")
               );
         });
+  }
+
+  @Test
+  void mapToActionInitPositionXYThetaAreDouble() {
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_INSTANT_ACTION_TYPE,
+        Map.of(
+            SEND_INSTANT_ACTION_PARAM_ACTION_TYPE, InitPosition.ACTION_TYPE,
+            SEND_INSTANT_ACTION_PARAM_ACTION_ID, "1",
+            SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE, BlockingType.NONE.name(),
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_X, "2.009",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_Y, "3.367",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_THETA,
+            "3.141592653589793",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_MAP_ID, "floor1",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_LAST_NODE_ID,
+            "io-0001"
+        )
+    );
+
+    var result = mapper.toAction(message);
+
+    assertThat(result).hasValueSatisfying(action -> {
+      // Numeric keys must be parsed as Double
+      assertThat(action.getActionParameters())
+          .extracting(ActionParameter::getKey, ActionParameter::getValue)
+          .contains(
+              tuple(InitPosition.PARAMKEY_X, 2.009),
+              tuple(InitPosition.PARAMKEY_Y, 3.367),
+              tuple(InitPosition.PARAMKEY_THETA, 3.141592653589793)
+          );
+      // String parameters must NOT be converted to numbers
+      assertThat(action.getActionParameters())
+          .extracting(ActionParameter::getKey, ActionParameter::getValue)
+          .contains(
+              tuple(InitPosition.PARAMKEY_MAP_ID, "floor1"),
+              tuple(InitPosition.PARAMKEY_LAST_NODE_ID, "io-0001")
+          );
+    });
+  }
+
+  @Test
+  void mapToActionInitPositionMapIdLookingNumericStaysString() {
+    // mapId of "1.0" must not be converted to Double even though it parses as a number
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_INSTANT_ACTION_TYPE,
+        Map.of(
+            SEND_INSTANT_ACTION_PARAM_ACTION_TYPE, InitPosition.ACTION_TYPE,
+            SEND_INSTANT_ACTION_PARAM_ACTION_ID, "1",
+            SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE, BlockingType.NONE.name(),
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_X, "1.0",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_Y, "2.0",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_THETA, "0.0",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_MAP_ID, "1.0",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_LAST_NODE_ID,
+            "io-0001"
+        )
+    );
+
+    var result = mapper.toAction(message);
+
+    assertThat(result).hasValueSatisfying(action -> {
+      assertThat(action.getActionParameters())
+          .extracting(ActionParameter::getKey, ActionParameter::getValue)
+          .contains(
+              tuple(InitPosition.PARAMKEY_X, 1.0),
+              tuple(InitPosition.PARAMKEY_Y, 2.0),
+              tuple(InitPosition.PARAMKEY_THETA, 0.0),
+              // "1.0" as mapId must remain a String, not become Double(1.0)
+              tuple(InitPosition.PARAMKEY_MAP_ID, "1.0")
+          );
+    });
+  }
+
+  @Test
+  void mapToActionInitPositionWithInvalidNumericIsNotMapped() {
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_INSTANT_ACTION_TYPE,
+        Map.of(
+            SEND_INSTANT_ACTION_PARAM_ACTION_TYPE, InitPosition.ACTION_TYPE,
+            SEND_INSTANT_ACTION_PARAM_ACTION_ID, "1",
+            SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE, BlockingType.NONE.name(),
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_X, "not-a-number",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_Y, "3.367",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_THETA, "0.0"
+        )
+    );
+
+    assertThat(mapper.toAction(message)).isEmpty();
+  }
+
+  @Test
+  void mapToOrderWithInvalidInitPositionNumericIsNotMapped() {
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_ORDER_TYPE,
+        Map.ofEntries(
+            Map.entry(SEND_ORDER_PARAM_ORDER_ID, "order-id"),
+            Map.entry(SEND_ORDER_PARAM_ORDER_UPDATE_ID, "7"),
+            Map.entry(SEND_ORDER_PARAM_SOURCE_NODE, "source-node"),
+            Map.entry(SEND_ORDER_PARAM_DESTINATION_NODE, "destination-node"),
+            Map.entry(SEND_ORDER_PARAM_EDGE, "edge"),
+            Map.entry(SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE, InitPosition.ACTION_TYPE),
+            Map.entry(SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_ID, "action-id"),
+            Map.entry(
+                SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_BLOCKING_TYPE,
+                BlockingType.NONE.name()
+            ),
+            Map.entry(
+                SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_PARAMETER_PREFIX + InitPosition.PARAMKEY_X,
+                "not-a-number"
+            )
+        )
+    );
+
+    when(objectService.fetch(Point.class, "source-node"))
+        .thenReturn(Optional.of(new Point("source-node")));
+    when(objectService.fetch(Point.class, "destination-node"))
+        .thenReturn(Optional.of(new Point("destination-node")));
+
+    assertThat(mapper.toOrder(message)).isEmpty();
   }
 }

--- a/src/test/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapperTest.java
+++ b/src/test/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapperTest.java
@@ -227,4 +227,69 @@ class CommAdapterMessageMapperTest {
           );
     });
   }
+
+  @Test
+  void mapToActionInitPositionWithInvalidNumericIsNotMapped() {
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_INSTANT_ACTION_TYPE,
+        Map.of(
+            SEND_INSTANT_ACTION_PARAM_ACTION_TYPE, InitPosition.ACTION_TYPE,
+            SEND_INSTANT_ACTION_PARAM_ACTION_ID, "1",
+            SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE, BlockingType.NONE.name(),
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_X, "not-a-number",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_Y, "3.367",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_THETA, "0.0"
+        )
+    );
+
+    assertThat(mapper.toAction(message)).isEmpty();
+  }
+
+  @Test
+  void mapToActionInitPositionWithNonFiniteNumericIsNotMapped() {
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_INSTANT_ACTION_TYPE,
+        Map.of(
+            SEND_INSTANT_ACTION_PARAM_ACTION_TYPE, InitPosition.ACTION_TYPE,
+            SEND_INSTANT_ACTION_PARAM_ACTION_ID, "1",
+            SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE, BlockingType.NONE.name(),
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_X, "Infinity",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_Y, "3.367",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_THETA, "0.0"
+        )
+    );
+
+    assertThat(mapper.toAction(message)).isEmpty();
+  }
+
+  @Test
+  void mapToOrderWithInvalidInitPositionNumericIsNotMapped() {
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_ORDER_TYPE,
+        Map.ofEntries(
+            Map.entry(SEND_ORDER_PARAM_ORDER_ID, "order-id"),
+            Map.entry(SEND_ORDER_PARAM_ORDER_UPDATE_ID, "7"),
+            Map.entry(SEND_ORDER_PARAM_SOURCE_NODE, "source-node"),
+            Map.entry(SEND_ORDER_PARAM_DESTINATION_NODE, "destination-node"),
+            Map.entry(SEND_ORDER_PARAM_EDGE, "edge"),
+            Map.entry(SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_TYPE, InitPosition.ACTION_TYPE),
+            Map.entry(SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_ID, "action-id"),
+            Map.entry(
+                SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_BLOCKING_TYPE,
+                BlockingType.NONE.name()
+            ),
+            Map.entry(
+                SEND_ORDER_PARAM_DESTINATION_NODE_ACTION_PARAMETER_PREFIX + InitPosition.PARAMKEY_X,
+                "not-a-number"
+            )
+        )
+    );
+
+    when(objectService.fetch(Point.class, "source-node"))
+        .thenReturn(Optional.of(new Point("source-node")));
+    when(objectService.fetch(Point.class, "destination-node"))
+        .thenReturn(Optional.of(new Point("destination-node")));
+
+    assertThat(mapper.toOrder(message)).isEmpty();
+  }
 }

--- a/src/test/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapperTest.java
+++ b/src/test/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/CommAdapterMessageMapperTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentcs.commadapter.vehicle.vda5050.v2_0.action.InitPosition;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.Action;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.ActionParameter;
 import org.opentcs.commadapter.vehicle.vda5050.v2_0.message.common.BlockingType;
@@ -153,5 +154,77 @@ class CommAdapterMessageMapperTest {
                   tuple("action-param-2", "value-2")
               );
         });
+  }
+
+  @Test
+  void mapToActionInitPositionXYThetaAreDouble() {
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_INSTANT_ACTION_TYPE,
+        Map.of(
+            SEND_INSTANT_ACTION_PARAM_ACTION_TYPE, InitPosition.ACTION_TYPE,
+            SEND_INSTANT_ACTION_PARAM_ACTION_ID, "1",
+            SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE, BlockingType.NONE.name(),
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_X, "2.009",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_Y, "3.367",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_THETA,
+            "3.141592653589793",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_MAP_ID, "floor1",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_LAST_NODE_ID,
+            "io-0001"
+        )
+    );
+
+    var result = mapper.toAction(message);
+
+    assertThat(result).hasValueSatisfying(action -> {
+      // Numeric keys must be parsed as Double
+      assertThat(action.getActionParameters())
+          .extracting(ActionParameter::getKey, ActionParameter::getValue)
+          .contains(
+              tuple(InitPosition.PARAMKEY_X, 2.009),
+              tuple(InitPosition.PARAMKEY_Y, 3.367),
+              tuple(InitPosition.PARAMKEY_THETA, 3.141592653589793)
+          );
+      // String parameters must NOT be converted to numbers
+      assertThat(action.getActionParameters())
+          .extracting(ActionParameter::getKey, ActionParameter::getValue)
+          .contains(
+              tuple(InitPosition.PARAMKEY_MAP_ID, "floor1"),
+              tuple(InitPosition.PARAMKEY_LAST_NODE_ID, "io-0001")
+          );
+    });
+  }
+
+  @Test
+  void mapToActionInitPositionMapIdLookingNumericStaysString() {
+    // mapId of "1.0" must not be converted to Double even though it parses as a number
+    VehicleCommAdapterMessage message = new VehicleCommAdapterMessage(
+        CommAdapterMessages.SEND_INSTANT_ACTION_TYPE,
+        Map.of(
+            SEND_INSTANT_ACTION_PARAM_ACTION_TYPE, InitPosition.ACTION_TYPE,
+            SEND_INSTANT_ACTION_PARAM_ACTION_ID, "1",
+            SEND_INSTANT_ACTION_PARAM_BLOCKING_TYPE, BlockingType.NONE.name(),
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_X, "1.0",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_Y, "2.0",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_THETA, "0.0",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_MAP_ID, "1.0",
+            SEND_INSTANT_ACTION_PARAM_PARAMETER_PREFIX + InitPosition.PARAMKEY_LAST_NODE_ID,
+            "io-0001"
+        )
+    );
+
+    var result = mapper.toAction(message);
+
+    assertThat(result).hasValueSatisfying(action -> {
+      assertThat(action.getActionParameters())
+          .extracting(ActionParameter::getKey, ActionParameter::getValue)
+          .contains(
+              tuple(InitPosition.PARAMKEY_X, 1.0),
+              tuple(InitPosition.PARAMKEY_Y, 2.0),
+              tuple(InitPosition.PARAMKEY_THETA, 0.0),
+              // "1.0" as mapId must remain a String, not become Double(1.0)
+              tuple(InitPosition.PARAMKEY_MAP_ID, "1.0")
+          );
+    });
   }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: The openTCS Authors
SPDX-License-Identifier: CC-BY-4.0
-->

## Description

Fix the Kernel Control Center initPosition command so that `x`, `y`,
and `theta` are sent as numeric values instead of strings.

## Checklist

- [x] You have the right to contribute the code/documentation/assets to this project, and you agree to contribute it under the terms of the project's license(s).
- [x] All changes have been made on a separate branch (not master) in a fork.
- [x] The whole project compiles correctly and all tests pass, i.e. `gradlew clean build` succeeds with the changes made, and without unavoidable compiler/toolchain warnings.
- [x] New tests covering the change have been added, if it is possible / makes sense.
- [ ] The documentation has been extended, if necessary.
- [x] The PR contains a proposal for a _well-formed_ commit message that mentions all authors who contributed to the PR.
      (The commits in the PR will be squashed into one commit on the base branch, and your proposed message is intended to be used for this commit. See below for a template you can use for the message. See [this blog post](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) and [this one](https://chris.beams.io/posts/git-commit/#seven-rules) for more on well-formed commit messages.)

## Proposed squash commit message

```
Fix initPosition coordinate types 

Send x, y, and theta as numeric (float) values in the
Kernel Control Center initPosition command 
as according to VDA5050 v2.0 documentation.

* add logic for parsing x, y and theta parameters as numeric
* validates x, y, theta are numeric before sending initPosition
* show error dialog and aborts sending if validation fails
```

<!--
*********1*********2*********3*********4*********5*********6*********7** (<-- Ruler for line width assistance)
-->
