### PR TITLE
VDA5050 2.0: stop resending accepted cancelOrder 

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,9 @@ toc::[]
 
 == Unreleased
 
+* New features and enhancements:
+** For VDA5050 2.0, stop resending a `cancelOrder` instant action once the vehicle reflects it in its `actionStates` (with any `actionStatus`, including a non-terminal one such as `RUNNING`).
+   The driver still waits for the action to reach `FINISHED`/`FAILED` before sending further messages.
 * Changes affecting developers:
 ** Update Gradle wrapper to 9.5.1.
 

--- a/doc/v2.0/runtime-behaviour.adoc
+++ b/doc/v2.0/runtime-behaviour.adoc
@@ -365,6 +365,10 @@ An instant action of type `cancelOrder` is automatically sent in the following c
 
 The instant action's blocking type is set to `NONE`.
 
+The vehicle driver transmits the `cancelOrder` instant action until the vehicle reflects it in its `actionStates` array.
+Once the vehicle reflects the action (with any `actionStatus`, including a non-terminal one such as `RUNNING`), the driver stops resending it.
+The driver still waits for the action's `actionStatus` to become `FINISHED` or `FAILED` before sending any further messages to the vehicle, so that a new order is never sent while the vehicle is still processing the cancellation.
+
 === `startPause`/`stopPause`
 
 An instant action of type `startPause`/`stopPause` is sent when the vehicle is paused/unpaused in openTCS.

--- a/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/MessageResponseMatcher.java
+++ b/src/main/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/MessageResponseMatcher.java
@@ -151,7 +151,7 @@ public class MessageResponseMatcher {
       return;
     }
 
-    if (requestAcknowledged(currentRequest, state)) {
+    if (requestComplete(currentRequest, state)) {
       requests.poll();
       if (currentRequest instanceof OrderAssociation) {
         OrderAssociation order = (OrderAssociation) currentRequest;
@@ -164,17 +164,44 @@ public class MessageResponseMatcher {
       }
       sendNextOrder();
     }
+    else if (requestAccepted(currentRequest, state)) {
+      // The vehicle reflects the request in its state but has not completed it yet (e.g. a
+      // cancelOrder that is still being processed). Stop resending the request, but keep it at the
+      // head of the queue so that subsequent requests remain blocked until it completes.
+      LOG.debug(
+          "{}: Request accepted but not yet completed. Waiting without resending: {}",
+          commAdapterName,
+          currentRequest
+      );
+    }
     else {
       sendNextOrder();
     }
   }
 
-  private boolean requestAcknowledged(Object request, State state) {
+  private boolean requestComplete(Object request, State state) {
     if (request instanceof OrderAssociation) {
       return orderAccepted(((OrderAssociation) request).getOrder(), state);
     }
     else if (request instanceof InstantActions) {
-      return instantActionsAcknowledged((InstantActions) request, state);
+      return instantActionsCompleted((InstantActions) request, state);
+    }
+    else {
+      LOG.warn(
+          "{}: Unrecognized request of type {}.",
+          commAdapterName,
+          request.getClass().getName()
+      );
+      return false;
+    }
+  }
+
+  private boolean requestAccepted(Object request, State state) {
+    if (request instanceof OrderAssociation) {
+      return orderAccepted(((OrderAssociation) request).getOrder(), state);
+    }
+    else if (request instanceof InstantActions) {
+      return instantActionsAccepted((InstantActions) request, state);
     }
     else {
       LOG.warn(
@@ -222,7 +249,7 @@ public class MessageResponseMatcher {
         && Objects.equals(state.getOrderUpdateId(), order.getOrderUpdateId());
   }
 
-  private boolean instantActionsAcknowledged(InstantActions instantAction, State state) {
+  private boolean instantActionsCompleted(InstantActions instantAction, State state) {
     return instantAction.getActions().stream()
         .allMatch(action -> {
           // In case of a cancelOrder action, we actually wait for the vehicle to accept AND
@@ -236,6 +263,19 @@ public class MessageResponseMatcher {
             return actionAccepted(action, state);
           }
         });
+  }
+
+  /**
+   * Checks whether the vehicle reflects all actions of the given instant actions message in its
+   * state, regardless of their (possibly non-terminal) action status.
+   *
+   * @param instantAction The instant actions message.
+   * @param state The vehicle's state.
+   * @return {@code true} if every action is present in the vehicle's {@code actionStates}.
+   */
+  private boolean instantActionsAccepted(InstantActions instantAction, State state) {
+    return instantAction.getActions().stream()
+        .allMatch(action -> actionAccepted(action, state));
   }
 
   private boolean actionAccepted(Action action, State state) {

--- a/src/test/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/MessageResponseMatcherTest.java
+++ b/src/test/java/org/opentcs/commadapter/vehicle/vda5050/v2_0/MessageResponseMatcherTest.java
@@ -269,22 +269,67 @@ public class MessageResponseMatcherTest {
 
     messageResponseMatcher.onStateMessage(stateAcceptingInstantAction(action1));
 
-    // The cancelOrder is repeated if the vehicle has accepted but not completed it yet.
-    verify(sendInstantActionsCallback, times(3)).accept(action1);
+    // The cancelOrder is no longer resent once the vehicle reflects it in its state, even though it
+    // has not completed it yet. The next request stays blocked until the cancelOrder completes.
+    verify(sendInstantActionsCallback, times(2)).accept(action1);
     verify(sendInstantActionsCallback, never()).accept(action2);
     verify(sendInstantActionsCallback, never()).accept(action3);
 
     messageResponseMatcher.onStateMessage(stateCompletingInstantAction(action1));
 
-    verify(sendInstantActionsCallback, times(3)).accept(action1);
+    verify(sendInstantActionsCallback, times(2)).accept(action1);
     verify(sendInstantActionsCallback, times(1)).accept(action2);
     verify(sendInstantActionsCallback, never()).accept(action3);
 
     messageResponseMatcher.onStateMessage(stateCompletingInstantAction(action2));
 
-    verify(sendInstantActionsCallback, times(3)).accept(action1);
+    verify(sendInstantActionsCallback, times(2)).accept(action1);
     verify(sendInstantActionsCallback, times(1)).accept(action2);
     verify(sendInstantActionsCallback, times(1)).accept(action3);
+  }
+
+  @Test
+  public void stopResendingCancelOrderWhenVehicleReportsItRunning() {
+    InstantActions cancelAction = new InstantActions();
+    cancelAction.setHeaderId(1L);
+    cancelAction.setActions(
+        List.of(new Action(CancelOrder.ACTION_TYPE, "cancel1", BlockingType.HARD))
+    );
+    InstantActions nextAction = new InstantActions();
+    nextAction.setHeaderId(2L);
+    nextAction.setActions(
+        List.of(new Action(CancelOrder.ACTION_TYPE, "cancel2", BlockingType.HARD))
+    );
+
+    messageResponseMatcher.enqueueAction(cancelAction);
+    messageResponseMatcher.enqueueAction(nextAction);
+
+    verify(sendInstantActionsCallback, times(1)).accept(cancelAction);
+    verify(sendInstantActionsCallback, never()).accept(nextAction);
+
+    // While the vehicle has not yet reflected the cancelOrder, it is resent.
+    messageResponseMatcher.onStateMessage(newState());
+    verify(sendInstantActionsCallback, times(2)).accept(cancelAction);
+
+    // Once the vehicle reports the cancelOrder as RUNNING, it must not be resent anymore, and the
+    // next request stays blocked.
+    messageResponseMatcher.onStateMessage(
+        stateWithActionStatus(cancelAction, ActionStatus.RUNNING)
+    );
+    verify(sendInstantActionsCallback, times(2)).accept(cancelAction);
+    verify(sendInstantActionsCallback, never()).accept(nextAction);
+
+    // Further RUNNING reports still do not trigger a resend.
+    messageResponseMatcher.onStateMessage(
+        stateWithActionStatus(cancelAction, ActionStatus.RUNNING)
+    );
+    verify(sendInstantActionsCallback, times(2)).accept(cancelAction);
+    verify(sendInstantActionsCallback, never()).accept(nextAction);
+
+    // Only when the cancelOrder completes does the matcher advance to the next request.
+    messageResponseMatcher.onStateMessage(stateCompletingInstantAction(cancelAction));
+    verify(sendInstantActionsCallback, times(2)).accept(cancelAction);
+    verify(sendInstantActionsCallback, times(1)).accept(nextAction);
   }
 
   @ParameterizedTest
@@ -359,6 +404,22 @@ public class MessageResponseMatcherTest {
         actions.getActions().stream()
             .map(
                 action -> new ActionState(action.getActionId(), ActionStatus.FINISHED)
+                    .setActionType(action.getActionType())
+            )
+            .toList()
+    );
+    return state;
+  }
+
+  private State stateWithActionStatus(
+      InstantActions actions,
+      ActionStatus status
+  ) {
+    State state = newState();
+    state.getActionStates().addAll(
+        actions.getActions().stream()
+            .map(
+                action -> new ActionState(action.getActionId(), status)
                     .setActionType(action.getActionType())
             )
             .toList()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: The openTCS Authors
SPDX-License-Identifier: CC-BY-4.0
-->

## Description

<!--
Please explain the changes you made here, and why you made them.
If this PR is related to an issue, reference it here.
Note that, with a reference to an issue and/or an expressive commit message (see below), you can usually keep this quite short.
-->

Fixes `cancelOrder` resend behavior in VDA5050 2.0.

`MessageResponseMatcher` now distinguishes:
- request completed
- request accepted but not completed 
- request not accepted 

For `cancelOrder`, once the vehicle reports the action in `actionStates`
(including non-terminal states like `RUNNING`), resending stops. The queue
still stays blocked until terminal completion (`FINISHED`/`FAILED`).

Also updates tests and runtime behavior documentation.

Related  issue: https://github.com/orgs/openTCS/discussions/266

## Checklist

- [x] You have the right to contribute the code/documentation/assets to this project, and you agree to contribute it under the terms of the project's license(s).
- [x] All changes have been made on a separate branch (not master) in a fork.
- [x] The whole project compiles correctly and all tests pass, i.e. `gradlew clean build` succeeds with the changes made, and without unavoidable compiler/toolchain warnings.
- [x] New tests covering the change have been added, if it is possible / makes sense.
- [x] The documentation has been extended, if necessary.
- [x] The PR contains a proposal for a _well-formed_ commit message that mentions all authors who contributed to the PR.
      (The commits in the PR will be squashed into one commit on the base branch, and your proposed message is intended to be used for this commit. See below for a template you can use for the message. See [this blog post](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) and [this one](https://chris.beams.io/posts/git-commit/#seven-rules) for more on well-formed commit messages.)

## Proposed squash commit message

<!--
A proposed message for the eventual squashed commit.
Please stick to the following pattern:

- A short one-line summary (max. 50 characters).
- A blank line.
- A detailed explanation of the changes introduced by this merge request.
  Each line should not exceed 72 characters.
*********1*********2*********3*********4*********5*********6*********7** (<-- Ruler for line width assistance)
-->

```
Stop resending accepted cancelOrder

For VDA5050 2.0, treat cancelOrder presence in actionStates as
acknowledged, including non-terminal states like RUNNING.

This prevents repeated transmission of the same cancelOrder while
still blocking subsequent queued requests until the action reaches a 
terminal state (FINISHED/FAILED).

Update matcher tests and runtime behavior documentation accordingly.
```
<!--
*********1*********2*********3*********4*********5*********6*********7** (<-- Ruler for line width assistance)
-->
